### PR TITLE
update readme and delete openjdk6 env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ language: java
 jdk:
   - oraclejdk8
   - oraclejdk7
-  - openjdk6
 
 # excute tests in only master and dev branch
 branches:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This is includes:
 |:------:|:---:|
 | [![Build Status](https://travis-ci.org/RealTwo-Space/Neumann.svg?branch=master)](https://travis-ci.org/RealTwo-Space/Neumann) |  [![Build Status](https://travis-ci.org/RealTwo-Space/Neumann.svg?branch=dev)](https://travis-ci.org/RealTwo-Space/Neumann)   |
 
+Compatible with Java7 and Java8
 ## Test Environment
 - Travis CI
 - JUnit 4.12
@@ -34,3 +35,28 @@ This is includes:
 1. Check your branch latest version.
 2. Check your checked out branch correct.
 
+## Construct Development Environment
+When we develop this project, we are using IDE - [IntelliJ](https://www.jetbrains.com/idea/). 
+We recommend you to use IntelliJ if you collaborate with us.
+Of course, you can use the other IDE like Eclipse.
+
+Here, how to construct environment with IntelliJ
+- download and unzip this [zip](https://github.com/RealTwo-Space/Neumann/archive/dev.zip) or in terminal,
+
+```
+$ git clone https://github.com/RealTwo-Space/Neumann.git
+```
+
+- boot IntelliJ
+
+- click File -> Open on the menu.
+
+- select Neumann folder
+
+- click file -> Project Structure...
+
+- Project Settings -> Project -> Project SDK -> select java SDK (We are using jdk 1.8)
+
+- Project settings -> Module -> Dependencies -> add new library and includes jUnit4 and hamcrest-core in the lib folder to the library.
+
+[more information](https://github.com/RealTwo-Space/Information)


### PR DESCRIPTION
I searched the difference between Java6 and Java7. Try Catch Syntax is little different. So I decided to delete openjdk6.
